### PR TITLE
Add RSS feeds

### DIFF
--- a/content/links/2016-09-15-gmail-is-going-responsive-finally.md
+++ b/content/links/2016-09-15-gmail-is-going-responsive-finally.md
@@ -1,16 +1,16 @@
 ---
 templateKey: link-post
 path: /links/2016-09-15-gmail-is-going-responsive-finally
-title: "Gmail is going responsive...finally!"
-summary:
-  "Have you ever opened an email on your phone and something about the formatting just looks … off? Maybe the text is hard to read, or the buttons and links too small to tap. That’s because many emails are still formatted for computers' larger screens, which means reading them on mobile can be a hassle."
+title: 'Gmail is going responsive...finally!'
+description: "Have you ever opened an email on your phone and something about the formatting just looks … off? Maybe the text is hard to read, or the buttons and links too small to tap. That’s because many emails are still formatted for computers' larger screens, which means reading them on mobile can be a hassle."
 date: 2016-09-15T12:12:33-05:00
 url: https://gmail.googleblog.com/2016/09/better-emails-tailored-to-all-your-devices.html
-image: 
+image:
 tags:
   - Email Development
   - Gmail
 ---
+
 If there ever was a post that deserved the finally moniker then this is it.
 
 Header styles and media query support is [coming to Gmail](https://gmail.googleblog.com/2016/09/better-emails-tailored-to-all-your-devices.html)

--- a/content/links/2016-10-05-samsung-is-in-trouble.md
+++ b/content/links/2016-10-05-samsung-is-in-trouble.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2016-10-05-samsung-is-in-trouble
 title: "Samsung is in Trouble"
-summary:
+description:
   "More worryingly, the phone in question was a replacement Galaxy Note 7, one that was deemed to be safe by Samsung."
 date: 2016-10-05T12:12:33-05:00
 url: http://www.theverge.com/2016/10/5/13175000/samsung-galaxy-note-7-fire-replacement-plane-battery-southwest

--- a/content/links/2016-10-05-text-spinners.md
+++ b/content/links/2016-10-05-text-spinners.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2016-10-05-text-spinners
 title: "Text Spinners"
-summary:
+description:
   "This project tries to mimic command line spinners like those from cli-spinners (where most of them are taken from) and bring them to the web."
 date: 2016-10-05T12:12:33-05:00
 url: https://maxbeier.github.io/text-spinners/

--- a/content/links/2016-10-12-google-and-monotype-release-noto-font-for-all-languages.md
+++ b/content/links/2016-10-12-google-and-monotype-release-noto-font-for-all-languages.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2016-10-12-google-and-monotype-release-noto-font-for-all-languages
 title: "Google and Monotype Release Noto Font for All Languages"
-summary:
+description:
   "Font lovers around the world rejoice! After six years of intense collaboration between Google and Monotype, Noto Font, the universal font, is here. With support for 800 languages, 100 written scripts and more than 110,000 characters, Google’s Noto is like the Babel Tower but without the confusion."
 date: 2016-10-12T12:12:33-05:00
 url: http://designmodo.com/noto-font/

--- a/content/links/2016-11-07-rdm.md
+++ b/content/links/2016-11-07-rdm.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2016-11-07-rdm
 title: "RDM"
-summary:
+description:
   "This is a tool that lets you use MacBook Pro Retina's highest and unsupported resolutions. As an example, a Retina MacBook Pro 13\" can be set to 3360×2100 maximum resolution, as opposed to Apple's max supported 1680×1050. It is accessible from the menu bar."
 date: 2016-11-07T12:12:33-05:00
 url: https://github.com/avibrazil/RDM

--- a/content/links/2017-01-18-css-evolution.md
+++ b/content/links/2017-01-18-css-evolution.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2017-01-18-css-evolution
 title: "CSS Evolution: From CSS, SASS, BEM, CSS Modules to Styled Components"
-summary:
+description:
   "Whatever technology you use whether it is SASS, BEM, CSS Modules or Styled Components there is no substitute for a well defined styling architecture that makes it intuitive for other developers to contribute to your code base without thinking too much, breaking or introducing new moving parts to the system."
 date: 2017-01-18T12:12:33-05:00
 url: https://medium.com/@perezpriego7/css-evolution-from-css-sass-bem-css-modules-to-styled-components-d4c1da3a659b

--- a/content/links/2017-02-09-animista.md
+++ b/content/links/2017-02-09-animista.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2017-02-09-animista
 title: "Animista"
-summary:
+description:
   CSS animations on demand.
 date: 2017-02-09T12:12:33-05:00
 url: http://animista.net/

--- a/content/links/2017-02-09-wait-animate.md
+++ b/content/links/2017-02-09-wait-animate.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2017-02-09-wait-animate
 title: "Wait! Animate"
-summary:
+description:
   "CSS doesn't provide an easy way to pause an animation before it loops around again. Yes, there's animation-delay but this simply denotes a delay at the very start of the animation, i.e on load. WAIT! Animate provides an easy way to calculate the keyframe percentages so that you can insert a delay between each animation iteration."
 date: 2017-02-09T12:12:33-05:00
 url: http://waitanimate.wstone.io/

--- a/content/links/2017-02-21-overcast-3.md
+++ b/content/links/2017-02-21-overcast-3.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2017-02-21-overcast-3
 title: "Overcast 3"
-summary:
+description:
   "Overcast 3 is now available, and it’s a huge update, mostly in the design and flow of the interface. I’ve been working on it since last summer, informed by over two years of testing, usage, and customer feedback."
 date: 2017-02-21T12:12:33-05:00
 url: https://marco.org/2017/02/20/overcast3

--- a/content/links/2017-10-21-story-css-grid-from-its-creators.md
+++ b/content/links/2017-10-21-story-css-grid-from-its-creators.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2017-10-21-story-css-grid-from-its-creators
 title: "The Story of CSS Grid, from It’s Creators"
-summary:
+description:
   "On October 17th, Microsoft’s Edge browser shipped its implementation of CSS Grid. This is a milestone for a number of reasons. First, it means that all major browsers now support this incredible layout tool. Second, it means that all major browsers rolled out their implementations in a single year(!), a terrific example of standards success and cross-browser collaboration. But third, and perhaps most interestingly, it closes the loop on a process that has been more than 20 years in the making."
 date: 2017-10-21T12:12:33-05:00
 url: https://alistapart.com/article/the-story-of-css-grid-from-its-creators

--- a/content/links/2017-10-23-ricos-cheatsheats.md
+++ b/content/links/2017-10-23-ricos-cheatsheats.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2017-10-22/ricos-cheatsheats
 title: "Rico’s Cheatsheats"
-summary:
+description:
   "Hey! I'm @rstacruz and this is a modest collection of cheatsheets I've written."
 date: 2017-10-23T02:32:55.000Z
 url: https://devhints.io/

--- a/content/links/2017-12-05-forecast-podcast-mp3-encoder-with-chapters.md
+++ b/content/links/2017-12-05-forecast-podcast-mp3-encoder-with-chapters.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2017-12-05-forecast:-podcast-mp3-encoder-with-chapters
 image: 2017-12-05-forecast-podcast-mp3-encoder-with-chapters.png
 title: "Forecast: Podcast MP3 Encoder With Chapters"
-summary:
+description:
   "NOTE: Forecast is still a beta. It has been tested and used in production for two years, but the interface is still a bit rough. Feedback is welcome in the Overcast Slack group.  The podcast MP3 post-production tool designed, developed, and used by professional podcasters."
 date: 2017-12-05T16:37:37-0500
 url: https://overcast.fm/forecast

--- a/content/links/2018-02-02-introducing-haiku.md
+++ b/content/links/2018-02-02-introducing-haiku.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2018-02-02-introducing-haiku
 title: "Introducing Haiku"
-summary:
+description:
   "Haiku is a design tool for animated user interfaces — for real apps. Think of it as a design portal to your team's codebase."
 date: 2018-02-02T21:59:04-0500
 url: http://haiku.ai/blog/introducing-haiku

--- a/content/links/2018-02-03-recreating-the-github-contribution-graph-with-css-grid-layout.md
+++ b/content/links/2018-02-03-recreating-the-github-contribution-graph-with-css-grid-layout.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2018-02-03-recreating-the-github-contribution-graph-with-css-grid-layout
 title: "Recreating the GitHub Contribution Graph With CSS Grid Layout"
-summary:
+description:
   "While learning CSS Grid Layout, I’ve found that the best way to internalise all the new concepts and terminology is by working on various layouts using them. Recently, I decided to try to recreate the GitHub Contribution graph using CSS Grid Layout, and found it was an interesting challenge."
 date: 2018-02-03T21:36:25-0500
 url: https://bitsofco.de/github-contribution-graph-css-grid/

--- a/content/links/2018-02-03-why-your-app-looks-better-in-sketch.md
+++ b/content/links/2018-02-03-why-your-app-looks-better-in-sketch.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2018-02-03-why-your-app-looks-better-in-sketch
 title: "Why Your App Looks Better In Sketch"
-summary:
+description:
   "Can you spot the differences between these two images?  The image on the left is a screenshot from Sketch, and the image on the right is a reproduction on iOS. These differences arise when the graphics are rendered."
 date: 2018-02-03T20:56:45-0500
 url: https://medium.com/@nathangitter/why-your-app-looks-better-in-sketch-3a01b22c43d7

--- a/content/links/2018-02-05-website-sameness.md
+++ b/content/links/2018-02-05-website-sameness.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2018-02-05-website-sameness™
 title: "Website Sameness™"
-summary:
+description:
   "It came across as (particularly trite) commentary about Website Sameness™. I suppose it was. I was looking at lots of sites as I was putting together The Power of Serverless. I was actually finding it funny how obtuse the navigation often is on a SaaS sites."
 date: 2018-02-05T22:00:46-0500
 url: https://css-tricks.com/website-sameness/

--- a/content/links/2018-02-06-integrating-imperative-apis-into-a-react-application.md
+++ b/content/links/2018-02-06-integrating-imperative-apis-into-a-react-application.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2018-02-06-integrating-imperative-apis-into-a-react-application
 title: "Integrating imperative APIs into a React application"
-summary:
+description:
   "The Netflix TV app plays videos not only when users choose to watch a title, but also while browsing to find something great to enjoy. When we rewrote our TV user interface in React, we set out to improve the developer experience of integrating video playback into the UI so we could more rapidly experiment with various video-centric user experiences."
 date: 2018-02-06T23:40:58-0500
 url: https://medium.com/netflix-techblog/integrating-imperative-apis-into-a-react-application-1257e1b45ac6

--- a/content/links/2018-02-06-modern-css-explained-for-dinosaurs.md
+++ b/content/links/2018-02-06-modern-css-explained-for-dinosaurs.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2018-02-06-modern-css-explained-for-dinosaurs
 title: "Modern CSS Explained for Dinosaurs"
-summary:
+description:
   CSS is strangely considered both one of the easiest and one of the hardest languages to learn as a web developer.
 date: 2018-02-06T14:03:41-0500
 url: https://medium.com/actualize-network/modern-css-explained-for-dinosaurs-5226febe3525

--- a/content/links/2018-02-06-reacts-new-context-api.md
+++ b/content/links/2018-02-06-reacts-new-context-api.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2018-02-06-reacts-new-context-api
 title: "React’s New Context API"
-summary:
+description:
   "It’s way more ergonomic, it’s no longer “experimental,” and it’s now a first-class API! OH, AND IT USES A RENDER PROP!  NOTE: This is a cross-post from my newsletter. I publish each email two weeks after it’s sent."
 date: 2018-02-06T23:50:12-0500
 url: https://blog.kentcdodds.com/reacts-%EF%B8%8F-new-context-api-70c9fe01596b

--- a/content/links/2018-02-06-smart-homes-and-vegetable-peelers.md
+++ b/content/links/2018-02-06-smart-homes-and-vegetable-peelers.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2018-02-06-smart-homes-and-vegetable-peelers
 title: "Smart Homes and Vegetable Peelers"
-summary:
+description:
   "My answers: yes, maybe and no.  My grandparents could probably have told you how many electric motors they owned. There were one or two in the car, one in the fridge, one in the vacuum cleaner and so on, and they owned maybe a dozen in total."
 date: 2018-02-06T23:42:40-0500
 url: https://www.ben-evans.com/benedictevans/2018/1/4/smart-homes-and-vegetable-peelers

--- a/content/links/2018-02-06-the-power-of-raw-on-iphone-part-2-editing-raw.md
+++ b/content/links/2018-02-06-the-power-of-raw-on-iphone-part-2-editing-raw.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2018-02-06-the-power-of-raw-on-iphone-part-2-editing raw
 title: "The Power of RAW on iPhone, Part 2: Editing RAW"
-summary:
+description:
   "This is the second in a series of posts on RAW photography on iPhone. I previously wrote about what RAW is by explaining a little on how cameras work, how you can use RAW, and what some key tradeoffs of using RAW are. New to this series? I suggest you start there."
 date: 2018-02-06T21:28:18-0500
 url: https://blog.halide.cam/the-power-of-raw-on-iphone-part-2-editing-raw-79f60983302f

--- a/content/links/2018-02-07-how-i-design-with-css-grid.md
+++ b/content/links/2018-02-07-how-i-design-with-css-grid.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2018-02-07-how-i-design-with-css-grid
 title: "How I Design With CSS Grid"
-summary:
+description:
   "After a couple of rounds of introducing CSS grid to people who haven’t tried it before, I found it wasn’t the implementation of grid that people asked questions about, rather, it was the bit before that. The actual planning of how a layout would be set up."
 date: 2018-02-07T14:06:00-0500
 url: https://www.chenhuijing.com/blog/how-i-design-with-css-grid/

--- a/content/links/2018-02-07-the-best-ux-is-no-user-interface-at-all.md
+++ b/content/links/2018-02-07-the-best-ux-is-no-user-interface-at-all.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2018-02-07-the-best-ux-is-no-user-interface-at-all
 title: "The Best UX Is No User Interface at All"
-summary:
+description:
   "Don’t judge me—I was listening to \"Mad World\" way before Donny Darko and that creepy rabbit. If none of those references landed with you, it’s probably because I’m super old. In the words of George Castanza, \"It’s not you, it’s me.\""
 date: 2018-02-07T16:10:08-0500
 url: https://css-tricks.com/best-ux-no-user-interface/

--- a/content/links/2018-02-08-behold-the-157-new-emoji-for-2018.md
+++ b/content/links/2018-02-08-behold-the-157-new-emoji-for-2018.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-02-08-behold,-the-157-new-emoji-for-2018
 image: 2018-02-08-behold-the-157-new-emoji-for-2018.jpg
 title: "Behold, the 157 New Emoji for 2018"
-summary:
+description:
   "The Unicode Emoji 11.0 set is final, adding 157 new emoji to the 2666 we previously had. While we have not yet seen how these will be drawn by Apple, Google, Microsoft, Facebook, and other vendors, Emojipedia has whipped up a set of sample emoji to present an idea of what they might look like."
 date: 2018-02-08T00:15:28-0500
 url: https://arstechnica.com/gadgets/2018/02/behold-the-157-new-emoji-for-2018/

--- a/content/links/2018-02-08-how-to-be-a-product-designer.md
+++ b/content/links/2018-02-08-how-to-be-a-product-designer.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-02-08-how-to-be-a-product-designer.
 image: 2018-02-08-how-to-be-a-product-designer.png
 title: "How to Be a Product Designer"
-summary:
+description:
   "I might be a Product Designer now, but I didn’t always know that’s what I would be when I started my career. Let me start at the beginning of my journey. I went to college for Fine Arts and had found my way to where I am through a lot of trial and error."
 date: 2018-02-08T23:23:41-0500
 url: https://uxdesign.cc/how-to-be-a-product-designer-1c14f19e772c

--- a/content/links/2018-02-09-drawing-from-the-past.md
+++ b/content/links/2018-02-09-drawing-from-the-past.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-02-09-drawing-from-the-past
 image: 2018-02-09-drawing-from-the-past.jpg
 title: "Drawing From The Past"
-summary:
+description:
   "Can you name all 24 events at the Winter Olympics at PyeongChang from memory? Of course not, nobody can. But I bet you could do really well if I showed you illustrations of each event. You can try it here."
 date: 2018-02-09T22:52:13-0500
 url: https://medium.com/@joshrose/drawing-from-the-past-5a8fe3029a58

--- a/content/links/2018-02-09-get-started-with-motion-design-in-9 steps.md
+++ b/content/links/2018-02-09-get-started-with-motion-design-in-9 steps.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-02-09-get-started-with-motion-design-in-9 steps
 image: 2018-02-09-get-started-with-motion-design-in-9 steps.png
 title: "Get Started With Motion Design in 9 steps"
-summary:
+description:
   "Animated means full of life and excitement. Animation adds life to static things. When it comes to software, it’s not just for delight but for solving problems."
 date: 2018-02-09T16:45:42-0500
 url: https://uxdesign.cc/motion-in-ux-design-9-points-to-get-started-e891974dc7ee

--- a/content/links/2018-02-09-the-philly-special-stuns-belichick-super-bowl-lii-eagles-vs-patriots-nfl-turning-point.md
+++ b/content/links/2018-02-09-the-philly-special-stuns-belichick-super-bowl-lii-eagles-vs-patriots-nfl-turning-point.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-02-09-the-philly-special-stuns-belichick-super-bowl-lii-eagles-vs-patriots-nfl-turning-point
 image: 2018-02-09-the-philly-special-stuns-belichick-super-bowl-lii-eagles-vs-patriots-nfl-turning-point.jpg
 title: "The \"Philly Special\" Stuns Belichick (Super Bowl LII)"
-summary:
+description:
   "Doug Pederson and Nick Foles go with a bold play call on fourth and goal to defeat the New England Patriots in Super Bowl LII."
 date: 2018-02-09T23:42:11-0500
 url: https://www.youtube.com/watch?v=Ye6dVwDb_u0

--- a/content/links/2018-02-10-branded-in-memory-nfl-edition.md
+++ b/content/links/2018-02-10-branded-in-memory-nfl-edition.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-02-10-branded-in-memory-nfl-edition
 image: 2018-02-10-branded-in-memory-nfl-edition.png
 title: "Branded in Memory: NFL Edition"
-summary:
+description:
   "Across the world, sports franchises and teams are big business, and in the U.S., the National Football League is king. The 32 teams that make up the NFL are worth slightly less than every club in the MLB and NBA combined."
 date: 2018-02-10T20:58:50-0500
 url: https://www.signs.com/branded-in-memory-nfl/

--- a/content/links/2018-02-13-unseen-1960s-photos-of-londons-east-end.md
+++ b/content/links/2018-02-13-unseen-1960s-photos-of-londons-east-end.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-02-13-unseen-1960s-photos-of-londons-east-end
 image: 2018-02-13-unseen-1960s-photos-of-londons-east-end.jpg
 title: "Unseen 1960s Photos of London's East End"
-summary:
+description:
   "We don’t know a whole lot about the life of the amateur photographer David Granick.  We know he was born in Stepney, an area of London’s East End, in 1912, as the eldest child of Anne Rabinovitch and Jonah Granick."
 date: 2018-02-13T13:40:48-0500
 url: https://www.atlasobscura.com/articles/pictures-london-east-end-1960s-color

--- a/content/links/2018-02-15-everything-easy-is-hard-again.md
+++ b/content/links/2018-02-15-everything-easy-is-hard-again.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-02-15-everything-easy-is-hard-again
 image: 2018-02-15-everything-easy-is-hard-again.png
 title: "Everything Easy Is Hard Again"
-summary:
+description:
   "This past summer, I gave a lecture at a web conference and afterward got into a fascinating conversation with a young digital design student. It was fun to compare where we were in our careers."
 date: 2018-02-15T12:12:26-0500
 url: https://www.frankchimero.com/writing/everything-easy-is-hard-again/

--- a/content/links/2018-02-16-using-prettier-to-format-your-javascript-code.md
+++ b/content/links/2018-02-16-using-prettier-to-format-your-javascript-code.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-02-16-using-prettier-to-format-your-javascript-code
 image: 2018-02-16-using-prettier-to-format-your-javascript-code.png
 title: "Using Prettier to Format Your JavaScript Code"
-summary:
+description:
   "If you have been programming for a while, you would be familiar with the hassles of writing clean code and maintaining consistency across a project on some specific code style guidelines."
 date: 2018-02-16T00:21:28-0500
 url: https://www.wisdomgeek.com/web-development/using-prettier-format-javascript-code/

--- a/content/links/2018-02-17-shipping-system-fonts-to-githubcom.md
+++ b/content/links/2018-02-17-shipping-system-fonts-to-githubcom.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-02-17-shipping-system-fonts-to-githubcom
 image: 2018-02-17-shipping-system-fonts-to-githubcom.png
 title: "Shipping System Fonts to GitHub.com"
-summary:
+description:
   "I’m finally publishing this blog post I drafted over a year ago. It was incomplete when I started to revisit it months ago, but I figured it’s better to share it now than sit on it forever. I’ve called out the additions and edits I made since that original draft."
 date: 2018-02-17T17:07:34-0500
 url: http://markdotto.com/2018/02/07/github-system-fonts/

--- a/content/links/2018-02-21-inside-the-federal-bureau-of-way-too-many-guns.md
+++ b/content/links/2018-02-21-inside-the-federal-bureau-of-way-too-many-guns.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-02-21-inside-the-federal-bureau-of-way-too-many-guns
 image: 2018-02-21-inside-the-federal-bureau-of-way-too-many-guns.jpg
 title: "Inside the Federal Bureau of Way Too Many Guns"
-summary:
+description:
   "There's no telling how many guns we have in America—and when one gets used in a crime, no way for the cops to connect it to its owner. The only place the police can turn for help is a Kafkaesque agency in West Virginia, where, thanks to the gun lobby, computers are illegal and detective work is absurdly antiquated. On purpose. Thing is, the geniuses who work there are quietly inventing ways to do the impossible."
 date: 2018-02-21T15:34:51-0500
 url: https://www.gq.com/story/inside-federal-bureau-of-way-too-many-guns

--- a/content/links/2018-02-21-reactjs-frequently-faced-problems.md
+++ b/content/links/2018-02-21-reactjs-frequently-faced-problems.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-02-21-reactjs-frequently-faced-problems
 image: 2018-02-21-reactjs-frequently-faced-problems.png
 title: "React.js Frequently Faced Problems"
-summary:
+description:
   "At jsComplete, we manage a slack account dedicated to helping code learners get unstuck. We receive some interesting problems every now and then but most of the asked questions are for common problems. I am creating this resource to write detailed instructions for the common problems beginner React."
 date: 2018-02-21T23:39:34-0500
 url: https://dev.to/samerbuna/reactjs-frequently-facedproblems--l5g

--- a/content/links/2018-02-21-the-house-that-spied-on-me.md
+++ b/content/links/2018-02-21-the-house-that-spied-on-me.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-02-21-the-house-that-spied-on-me
 image: 2018-02-21-the-house-that-spied-on-me.png
 title: "The House That Spied on Me"
-summary:
+description:
   "I thought the house would take care of me but instead everything in it now had the power to ask me to do things. Ultimately, I’m not going to warn you against making everything in your home smart because of the privacy risks, although there are quite a few. I’m going to warn you against a smart home because living in it is annoying as hell."
 date: 2018-02-21T10:01:50-0500
 url: http://gizmodo.com/the-house-that-spied-on-me-1822429852

--- a/content/links/2018-02-22-writer-sometimes-designer-web-email-advocate.md
+++ b/content/links/2018-02-22-writer-sometimes-designer-web-email-advocate.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-02-22-writer-sometimes-designer-web-email-advocate
 image: 2018-02-22-writer-sometimes-designer-web-email-advocate.jpg
 title: "Writer, Sometimes Designer, Web + Email Advocate."
-summary:
+description:
   "I’m an email guy. I’ve written three books on email, spoken at a bunch of conferences on the topic, and help build tools for other email folks at my day job. I love seeing the email platform grow and evolve."
 date: 2018-02-22T23:52:06-0500
 url: https://www.rodriguezcommaj.com/blog/on-amp-for-email

--- a/content/links/2018-02-27-dont-take-design-critique-as-an-insult.md
+++ b/content/links/2018-02-27-dont-take-design-critique-as-an-insult.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-02-27-dont-take-design-critique-as-an-insult
 image: 2018-02-27-dont-take-design-critique-as-an-insult.jpg
 title: "Don’t Take Design Critique as An insult"
-summary:
+description:
   "Design critique sessions are nothing new. They are an integral part of the design process, and over the last years modern companies have found smart and efficient ways to incorporate these sessions into everything they design and build."
 date: 2018-02-27T11:02:08-0500
 url: https://uxdesign.cc/dont-take-design-critique-as-an-insult-6cf187ca6308

--- a/content/links/2018-02-27-life-on-an-ipad.md
+++ b/content/links/2018-02-27-life-on-an-ipad.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-02-27-life-on-an-ipad
 image: 2018-02-27-life-on-an-ipad.jpg
 title: "Life on an iPad"
-summary:
+description:
   "A couple of weeks ago, I opened my Macbook Pro as usual. The keyboard lit up, as usual. I waited – there’s that pause while the display gathers itself (it’s a 2012 model) and the processor pulls everything together and presents the login window.  Except this time, nothing."
 date: 2018-02-27T01:24:41-0500
 url: https://theoverspill.blog/2018/02/19/ipad-work-python-workflow-mac-replacement/

--- a/content/links/2018-03-05-ccostanhome-assistantconfig.md
+++ b/content/links/2018-03-05-ccostanhome-assistantconfig.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-03-05-ccostan-home-assistant-config
 image: 2018-03-05-ccostan-home-assistant-config.png
 title: "CCOSTAN/Home-AssistantConfig"
-summary:
+description:
   "This is my Home Assistant Configuration created with the All In One installer expanded to 16GB. I update it pretty regularly. Home Assistant runs on my Raspberry Pi 3 with Aeon Labs Z Wave Stick (GEN 5). I've also added a 433Mhz Transmitter and receiver. The main SD Card was upgraded to 16GB."
 date: 2018-03-05T16:13:43-0500
 url: https://github.com/CCOSTAN/Home-AssistantConfig

--- a/content/links/2018-03-07-progressive-web-apps-are-coming-to-a-safari-near-you.md
+++ b/content/links/2018-03-07-progressive-web-apps-are-coming-to-a-safari-near-you.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-03-07-progressive-web-apps-are-coming-to-a-safari-near-you
 image:
 title: "Progressive Web Apps (PWAs) Are Coming to a Safari Near you"
-summary:
+description:
   "Safari is finally adding PWA features.  For those of you who have no clue what a PWA is or are confused about how to begin developing a PWA or don't know about it's importance please read this post on PWA before you proceed."
 date: 2018-03-07T06:14:33-0500
 url: https://medium.com/awebdeveloper/progressive-web-apps-pwas-are-coming-to-a-safari-near-you-216812aba5a

--- a/content/links/2018-03-11-awaityjs.md
+++ b/content/links/2018-03-11-awaityjs.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-03-11-awaityjs
 image: 2018-03-11-awaityjs.png
 title: "Awaity.js"
-summary:
+description:
   "Functional utility library for async / await  Think lodash for promises.  Bluebird's powerful collections methods, built with native promises  Use functions like map, reduce, filter & some to interate over promises in an intuitive way."
 date: 2018-03-11T15:01:04-0400
 url: https://github.com/asfktz/Awaity.js

--- a/content/links/2018-03-19-pinterest-gestalt.md
+++ b/content/links/2018-03-19-pinterest-gestalt.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-03-19-pinterest-gestalt
 image: 2018-03-19-pinterest-gestalt.png
 title: "Gestalt"
-summary:
+description:
   "Gestalt is a set of React UI components that enforces Pinterest’s design language. We use it to streamline communication between designers and developers by enforcing a bunch of fundamental UI components. This common set of components helps raise the bar for UX & accessibility across Pinterest."
 date: 2018-03-19T14:32:33-0400
 url: https://github.com/pinterest/gestalt

--- a/content/links/2018-03-19-variable-fonts-beta.md
+++ b/content/links/2018-03-19-variable-fonts-beta.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-03-19-variable-fonts-beta
 image: 2018-03-19-variable-fonts-beta.png
 title: "Variable Fonts (Beta)"
-summary:
+description:
   "Venn VF is the first family from Dalton Maag to be distributed as a variable font. It’s offered for free as a technology preview for use in commercial and non-commercial work until March 1, 2019.  ​A typeface designed for use in informational design."
 date: 2018-03-19T14:32:08-0400
 url: https://v-fonts.com/

--- a/content/links/2018-03-22-bringing-interactive-examples-to-mdn-mozilla-hacks-the-web-developer-blog.md
+++ b/content/links/2018-03-22-bringing-interactive-examples-to-mdn-mozilla-hacks-the-web-developer-blog.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-03-22-bringing-interactive-examples-to-mdn-mozilla-hacks-the-web-developer-blog
 image: 2018-03-22-bringing-interactive-examples-to-mdn-mozilla-hacks-the-web-developer-blog.png
 title: "Bringing Interactive Examples to MDN – Mozilla Hacks : The Web Developer Blog"
-summary:
+description:
   "Over the last year and a bit, the MDN Web Docs team has been designing, building, and implementing interactive examples for our reference pages."
 date: 2018-03-22T14:54:21-0400
 url: https://hacks.mozilla.org/2018/03/bringing-interactive-examples-to-mdn

--- a/content/links/2018-03-25-new-things-css-grid-brings-to-the table.md
+++ b/content/links/2018-03-25-new-things-css-grid-brings-to-the table.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-03-25-new-things-css-grid-brings-to-the table
 image: 2018-03-25-new-things-css-grid-brings-to-the table.png
 title: "New Things CSS Grid Brings to The Table"
-summary:
+description:
   "This CSS grid tutorial was inevitable. Since this is such a hot topic these days. This is the JavaScript Teacher’s interpretation of CSS grid. Like it or hate it.  Still don’t believe me? Well, I created these diagrams..."
 date: 2018-03-25T22:32:10-0400
 url: https://medium.com/@js_tut/new-things-css-grid-brings-to-the-table-e465cb5d2841

--- a/content/links/2018-03-27-charles-for-ios.md
+++ b/content/links/2018-03-27-charles-for-ios.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-03-27-charles-for-ios
 image: 2018-03-27-charles-for-ios.png
 title: "Charles for iOS"
-summary:
+description:
   "We are excited to announce that Charles Proxy is now available on iOS!  With the iOS version of Charles you can capture and inspect network requests and responses on your iOS device."
 date: 2018-03-27T23:23:41-0400
 url: https://www.charlesproxy.com/documentation/ios/

--- a/content/links/2018-03-29-system-fonts-in-css.md
+++ b/content/links/2018-03-29-system-fonts-in-css.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-03-29-system-fonts-in-css
 image: 2018-03-29-system-fonts-in-css.png
 title: "System Fonts in CSS"
-summary:
+description:
   "About three years ago, I wrote a piece on how to get system fonts in CSS. The San Francisco fonts had just been released and getting them onto a web page wasn’t obvious or easy. A recent tweet reminded me that I needed to update this information."
 date: 2018-03-29T09:03:40-0400
 url: https://furbo.org/2018/03/28/system-fonts-in-css/

--- a/content/links/2018-04-06-working-with-the-new-css-typed-object-model.md
+++ b/content/links/2018-04-06-working-with-the-new-css-typed-object-model.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-04-06-working-with-the-new-css-typed-object-model
 image:
 title: "Working With the New CSS Typed Object Model"
-summary:
+description:
   "CSS now has a proper object-based API for working with values in JavaScript.  The days of concatenating strings and subtle bugs are over!"
 date: 2018-04-06T12:49:59-0400
 url: https://developers.google.com/web/updates/2018/03/cssom

--- a/content/links/2018-04-10-storybook-tutorial.md
+++ b/content/links/2018-04-10-storybook-tutorial.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-04-10-storybook-tutorial
 image: 2018-04-10-storybook-tutorial.png
 title: "Storybook Tutorial"
-summary:
+description:
   "Learn Storybook aims to teach tried-and-true patterns for component development using Storybook. You’ll walk through essential UI component techniques while building a UI from scratch in React (Vue and Angular coming soon)."
 date: 2018-04-10T23:11:29-0400
 url: https://learnstorybook.com

--- a/content/links/2018-04-13-my-9-7-ipad-2018-review-drawn-written-edited-and-produced-with-an-ipad.md
+++ b/content/links/2018-04-13-my-9-7-ipad-2018-review-drawn-written-edited-and-produced-with-an-ipad.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-04-13-my-9-7-ipad-2018-review-drawn-written-edited-and-produced-with-an-ipad
 image: 2018-04-13-my-9-7-ipad-2018-review-drawn-written-edited-and-produced-with-an-ipad.jpg
 title: "My 9.7 iPad (2018) Review: Drawn, Written, Edited, and Produced With an iPad"
-summary:
+description:
   "For about a year, I worked exclusively on an iPad Pro. During that time I learned a lot about the highs (and massive lows) of iPad productivity, fell in love with the Apple Pencil, and discovered how best to balance my iPad and Mac lifestyle."
 date: 2018-04-13T22:00:44-0400
 url: https://www.imore.com/my-97-ipad-2018-review-drawn-written-edited-and-produced-ipad

--- a/content/links/2018-04-19-swipe-views-with-css-snap-points-building-a-more-efficient-mobile-web-navigation.md
+++ b/content/links/2018-04-19-swipe-views-with-css-snap-points-building-a-more-efficient-mobile-web-navigation.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-04-19-swipe-views-with-css-snap-points-building-a-more-efficient-mobile-web-navigation
 image: 2018-04-19-swipe-views-with-css-snap-points-building-a-more-efficient-mobile-web-navigation.png
 title: "Swipe Views With CSS Snap Points: Building a More Efficient Mobile Web Navigation"
-summary:
+description:
   "The mobile web has been making a lot of progress in the last year or two and I have happily replaced few native apps on my phone with their web alternatives and today I’m a full-time user of Twitter Lite and Instagram PWA."
 date: 2018-04-19T12:13:56-0400
 url: https://medium.com/@_zouhir/swipe-views-with-css-snap-points-building-a-more-efficient-mobile-web-navigation-f9ac8c53dbc0

--- a/content/links/2018-04-29-how-to-use-reacts-new-context-api-to-easily-manage-modals.md
+++ b/content/links/2018-04-29-how-to-use-reacts-new-context-api-to-easily-manage-modals.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-04-29-how-to-use-reacts-new-context-api-to-easily-manage-modals
 image: 2018-04-29-how-to-use-reacts-new-context-api-to-easily-manage-modals.png
 title: "How to Use React’s New Context API to Easily Manage modals"
-summary:
+description:
   "How many times have you been frustrated with having to add another item in your React state along with 2 functions for opening and closing a modal ? Not to mention if you have multiple modals or you need to send them different params based on a user’s action.  From React 16."
 date: 2018-04-29T10:11:23-0400
 url: https://medium.com/@BogdanSoare/how-to-use-reacts-new-context-api-to-easily-manage-modals-2ae45c7def81

--- a/content/links/2018-05-09-building-a-progressive-web-app-in-react.md
+++ b/content/links/2018-05-09-building-a-progressive-web-app-in-react.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-05-09-building-a-progressive-web-app-in-react
 image: 2018-05-09-building-a-progressive-web-app-in-react.png
 title: "Building a Progressive Web App In React"
-summary:
+description:
   "In case you haven’t heard, Progressive Web Apps (PWAs) are finally ready for prime time.  It might not yet be obvious to many people how to install a PWA, but if you’ve done it once you won’t forget it and it’s simpler than using an app store."
 date: 2018-05-09T10:06:05-0400
 url: https://blog.truthlabs.com/building-a-progressive-web-app-in-react-11c77a7fccb3

--- a/content/links/2018-05-11-how-you-can-develop-progressive-web-apps-that-feel-native.md
+++ b/content/links/2018-05-11-how-you-can-develop-progressive-web-apps-that-feel-native.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-05-11-how-you-can-develop-progressive-web-apps-that-feel-native
 image: 2018-05-11-how-you-can-develop-progressive-web-apps-that-feel-native.png
 title: "How You Can Develop Progressive Web Apps That Feel native"
-summary:
+description:
   "I’m currently developing a Progressive Web App that will also serve as the native app of my next service."
 date: 2018-05-11T11:06:34-0400
 url: https://medium.freecodecamp.org/how-you-can-develop-progressive-web-apps-that-feel-native-5110fbbcbf4b

--- a/content/links/2018-05-17-after-5-years-and-$3m-here-s-everything-we-ve-learned-from-building-ghost.md
+++ b/content/links/2018-05-17-after-5-years-and-$3m-here-s-everything-we-ve-learned-from-building-ghost.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-05-17-after-5-years-and-$3m-here-s-everything-we-ve-learned-from-building-ghost
 image: 2018-05-17-after-5-years-and-$3m-here-s-everything-we-ve-learned-from-building-ghost.jpg
 title: "After 5 Years and $3M, Here's Everything We've Learned From Building Ghost"
-summary:
+description:
   "Last week marked the fifth anniversary since the Ghost Kickstarter campaign which started it all.  It's always fun to use these milestones to take a step back and reflect on the journey so far."
 date: 2018-05-17T22:08:16-0400
 url: https://blog.ghost.org/5/

--- a/content/links/2018-05-25-wired-elements.md
+++ b/content/links/2018-05-25-wired-elements.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-05-25-wired-elements
 image: 2018-05-25-wired-elements.png
 title: "Wired Elements"
-summary:
+description:
   "A set of common UI elements with a hand-drawn, sketchy look. These can be used for wireframes, mockups, or just the fun hand-drawn look.  Wired Elements are implemented as web components. Web components are awesome!"
 date: 2018-05-25T04:32:52-0400
 url: https://wiredjs.com/

--- a/content/links/2018-05-28-filidorwiesespriteling.md
+++ b/content/links/2018-05-28-filidorwiesespriteling.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-05-28-filidorwiese/spriteling
 image: 2018-05-28-filidorwiesespriteling.png
 title: "Filidorwiese/Spriteling"
-summary:
+description:
   "A scriptable spritesheet animation engine that works directly on DOM elements (no canvas). It's build as ES5 compatible JavaScript, has no external dependencies and a tiny footprint (~3KB minified/gzipped).  Create a DOM element on the page and give it an id."
 date: 2018-05-28T14:59:34-0400
 url: https://github.com/filidorwiese/spriteling

--- a/content/links/2018-05-28-painless-html-email-coding.md
+++ b/content/links/2018-05-28-painless-html-email-coding.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-05-28-painless-html-email-coding
 image: 2018-05-28-painless-html-email-coding.jpeg
 title: "Painless HTML Email coding"
-summary:
+description:
   "Front-end development is fun and all until you have to style your first HTML email template. You think, “It’s just HTML… It can’t be THAT hard…”  It’s more complicated than it seems. Email clients vastly differ in their support for, even really simple, HTML and CSS features."
 date: 2018-05-28T15:01:34-0400
 url: https://medium.com/applantic/painless-html-email-coding-fdbe2fcc56b8

--- a/content/links/2018-05-29-dynamic-bézier-curves.md
+++ b/content/links/2018-05-29-dynamic-bézier-curves.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-05-29-dynamic-bézier-curves
 image:
 title: "Dynamic Bézier Curves"
-summary:
+description:
   "First off - woohoo! This is my first published post on the new blog. I'm super excited. Thanks for checking it out! ?  While building this blog, I wanted it to feel whimsical, with plenty of charming interactions and animations."
 date: 2018-05-29T13:46:47-0400
 url: https://www.joshwcomeau.com/posts/dynamic-bezier-curves

--- a/content/links/2018-05-29-let’s-fall-in-love-with-react-fiber.md
+++ b/content/links/2018-05-29-let’s-fall-in-love-with-react-fiber.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-05-29-let’s-fall-in-love-with-react fiber
 image: 2018-05-29-let’s-fall-in-love-with-react-fiber.jpg
 title: "Let’s Fall in Love With React Fiber"
-summary:
+description:
   "With Fiber, React can pause and resume work at will to get what matters on screen as quickly as possible!"
 date: 2018-05-29T14:08:57-0400
 url: https://medium.freecodecamp.org/lets-fall-in-love-with-react-fiber-90f2e1f68ded

--- a/content/links/2018-06-02-javascript-es6-iterables-and-iterators.md
+++ b/content/links/2018-06-02-javascript-es6-iterables-and-iterators.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-06-02-javascript-es6-iterables-and-iterators
 image: 2018-06-02-javascript-es6-iterables-and-iterators.png
 title: "Javascript ES6 — Iterables and Iterators"
-summary:
+description:
   "Without iterable, it is difficult to manage the iteration on data for various type of data structures i.e iterating on array is different from iterating on an object."
 date: 2018-06-02T22:40:33-0400
 url: https://medium.com/@ideepak.jsd/javascript-es6-iterables-and-iterators-de18b54f4d4

--- a/content/links/2018-06-06-mythically-massive-and-powerful-waves.md
+++ b/content/links/2018-06-06-mythically-massive-and-powerful-waves.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-06-06-mythically-massive-and-powerful-waves
 image: 2018-06-06-mythically-massive-and-powerful-waves.jpg
 title: "Mythically Massive and Powerful Waves"
-summary:
+description:
   "Are you a mountains or a beach person? I prefer the beach — the ocean in particular, even though it scares the hell out of me sometimes. Photographer Rachael Talibart captures the power of the sea with her photos of waves kicked up by storms."
 date: 2018-06-06T09:58:26-0400
 url: https://kottke.org/18/06/mythically-massive-and-powerful-waves

--- a/content/links/2018-06-13-shortcuts-a-new-vision-for-siri-and-ios-automation.md
+++ b/content/links/2018-06-13-shortcuts-a-new-vision-for-siri-and-ios-automation.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-06-13-shortcuts-a-new-vision-for-siri-and-ios-automation
 image: 2018-06-13-shortcuts-a-new-vision-for-siri-and-ios-automation.jpeg
 title: "Shortcuts: A New Vision for Siri and iOS Automation"
-summary:
+description:
   "In my Future of Workflow article from last year (published soon after the news of Apple's acquisition), I outlined some of the probable outcomes for the app."
 date: 2018-06-13T22:59:28-0400
 url: https://www.macstories.net/stories/shortcuts-a-new-vision-for-siri-and-ios-automation/

--- a/content/links/2018-06-22-harnessing-the-power-of-animated-vector-drawables.md
+++ b/content/links/2018-06-22-harnessing-the-power-of-animated-vector-drawables.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-06-22-harnessing-the-power-of-animated-vector-drawables
 image: 2018-06-22-harnessing-the-power-of-animated-vector-drawables.png
 title: "Harnessing the Power of Animated Vector Drawables"
-summary:
+description:
   "Dealing with the UI/UX portion of the development process can be a very daunting task, whether you work as part of a team, or as an indie developer(like me)."
 date: 2018-06-22T13:57:19-0400
 url: https://uxdesign.cc/harnessing-the-power-of-animated-vector-drawables-6c700c7d7ef6

--- a/content/links/2018-06-28-canner.md
+++ b/content/links/2018-06-28-canner.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-06-28-canner
 image: 2018-06-28-canner.png
 title: "Canner"
-summary:
+description:
   "Canner is a universal CMS framework that allows you to build CMS in React JSX(XML-like) for Firebase, GraphQL, Restful API, Prisma, in other words, an agnostic CMS framework for any applications and data sources."
 date: 2018-06-28T16:37:25-0400
 url: https://www.canner.io

--- a/content/links/2018-07-02-apple-is-rebuilding-maps-from-the-ground-up.md
+++ b/content/links/2018-07-02-apple-is-rebuilding-maps-from-the-ground-up.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-07-02-apple-is-rebuilding-maps-from-the-ground-up
 image: 2018-07-02-apple-is-rebuilding-maps-from-the-ground-up.png
 title: "Apple Is Rebuilding Maps From the Ground Up"
-summary:
+description:
   "I’m not sure if you’re aware, but the launch of Apple Maps went poorly."
 date: 2018-07-02T20:58:01-0400
 url: https://techcrunch.com/2018/06/29/apple-is-rebuilding-maps-from-the-ground-up/

--- a/content/links/2018-07-02-does-it-mutate.md
+++ b/content/links/2018-07-02-does-it-mutate.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-07-02-does-it-mutate
 image:
 title: "Does It Mutate?"
-summary:
+description:
   "The concat() method is used to merge two or more arrays. This method does not change the existing arrays, but instead returns a new array.  The copyWithin() method shallow copies part of an array to another location in the same array and returns it, without modifying its size."
 date: 2018-07-02T21:00:21-0400
 url: https://doesitmutate.xyz/

--- a/content/links/2018-08-13-data-science-on-your-ipad.md
+++ b/content/links/2018-08-13-data-science-on-your-ipad.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-08-13-data-science-on-your-ipad
 image: 2018-08-13-data-science-on-your-ipad.jpg
 title: "Data Science on Your iPad"
-summary:
+description:
   "This article is a follow-up transcription to a talk I recently gave at a local Munich machine learning meetup. Unlike my previous talk, this time I wanted to convey the idea of using an iPad for actively running data science experiments, as opposed to passively consuming information."
 date: 2018-08-13T10:53:53-0400
 url: https://preslav.me/2018/08/12/data-science-on-your-ipad/

--- a/content/links/2018-08-26-advanced-effects-with-css-background-blend-modes.md
+++ b/content/links/2018-08-26-advanced-effects-with-css-background-blend-modes.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-08-26-advanced-effects-with-css-background-blend-modes
 image: 2018-08-26-advanced-effects-with-css-background-blend-modes.jpeg
 title: "Advanced Effects With CSS Background Blend modes"
-summary:
+description:
   "If a picture is worth a thousand words, then blending two pictures together must be worth many times that. Likewise, the design possibilities that open up with the availability of blend modes in CSS are likely greater than you realize."
 date: 2018-08-26T15:07:14-0400
 url: https://blog.logrocket.com/advanced-effects-with-css-background-blend-modes-4b750198522a

--- a/content/links/2018-08-27-watch-48-minutes-of-cyberpunk-2077-gameplay-in-4k.md
+++ b/content/links/2018-08-27-watch-48-minutes-of-cyberpunk-2077-gameplay-in-4k.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-08-27-watch-48-minutes-of-cyberpunk-2077-gameplay-in-4k
 image: 2018-08-27-watch-48-minutes-of-cyberpunk-2077-gameplay-in-4k.jpg
 title: "Watch 48 Minutes of Cyberpunk 2077 Gameplay in 4K"
-summary:
+description:
   "CD Projekt, the Poland-based game publisher responsible for The Witcher, just published 48 minutes of gameplay footage for its upcoming title Cyberpunk 2077, a futuristic sci-fi open-world game that generated a lot of buzz at this year’s E3."
 date: 2018-08-27T14:41:13-0400
 url: https://www.theverge.com/2018/8/27/17787600/cyberpunk-2077-cd-projekt-red-48-minutes-gameplay-demo-reveal

--- a/content/links/2018-09-17-making-ifttt-work-with-apple’s-new-shortcuts-app.md
+++ b/content/links/2018-09-17-making-ifttt-work-with-apple’s-new-shortcuts-app.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-09-17-making-ifttt-work-with-apple’s-new-shortcuts-app
 image: 2018-09-17-making-ifttt-work-with-apple’s-new-shortcuts-app.png
 title: "Making IFTTT Work With Apple’s New Shortcuts App"
-summary:
+description:
   "Just want to skip to the steps? Ctrl+F for “How to fix it”.  Back in June when Apple announced iOS 12 they touted a bunch of new features including Animoji, ARKit 2, better notifications, and Screen Time."
 date: 2018-09-17T18:23:21-0400
 url: https://medium.com/@flat/making-ifttt-work-with-apples-new-shortcuts-app-5530e50d4527

--- a/content/links/2018-09-26-how-to-create-siri-shortcuts-beyond-your-iphone.md
+++ b/content/links/2018-09-26-how-to-create-siri-shortcuts-beyond-your-iphone.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-09-26-how-to-create-siri-shortcuts-beyond-your-iphone
 image: 2018-09-26-how-to-create-siri-shortcuts-beyond-your-iphone.png
 title: "How to Create Siri Shortcuts Beyond Your iPhone"
-summary:
+description:
   "Ever wished you could have Siri do your job for you? With iOS 12 and the new Shortcuts app, you can finally customize Siri. Set up a workflow, then tell Siri what to do, and it can send emails and save contacts and more for you automatically."
 date: 2018-09-26T22:22:04-0400
 url: https://zapier.com/blog/zapier-siri-shortcuts/

--- a/content/links/2018-09-26-learn-siri-shortcuts-part-3-magic-variables,-menu-action,-and-more!.md
+++ b/content/links/2018-09-26-learn-siri-shortcuts-part-3-magic-variables,-menu-action,-and-more!.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-09-26-learn-siri-shortcuts-part-3-magic-variables-menu-action-and-more
 image: 2018-09-26-learn-siri-shortcuts-part-3-magic-variables-menu-action-and-more.jpg
 title: "Learn Siri Shortcuts Part 3: Magic Variables, Menu Action, and More!"
-summary:
+description:
   "Let’s take another look at Siri Shortcuts! In this video we will take a look at magic variables, the menu action, and more. We will also cover a few shortcuts that hook into Things 3, Do Not Disturb, and Apple Music. Add to Shopping List: https://www.icloud.com/shortcuts/9524...Work Time: https://"
 date: 2018-09-26T22:23:18-0400
 url: https://www.youtube.com/watch?v=ocrR6Z_B_74

--- a/content/links/2018-09-27-adding-device-frames-to-iphone-xs-and-xs-max-screenshots-with-shortcuts.md
+++ b/content/links/2018-09-27-adding-device-frames-to-iphone-xs-and-xs-max-screenshots-with-shortcuts.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2018-09-27-adding-device-frames-to-iphone-xs-and-xs-max-screenshots-with-shortcuts
 image: 2018-09-27-adding-device-frames-to-iphone-xs-and-xs-max-screenshots-with-shortcuts.jpeg
 title: "Adding Device Frames to iPhone XS and XS Max Screenshots With Shortcuts"
-summary:
+description:
   "MacStories readers may be familiar with the way I like to present iPhone screenshots in app reviews and other stories - particularly for 'hero' images, such as the one above, I want my screenshots to be contained in device frames that resemble official marketing images from Apple."
 date: 2018-09-27T10:48:53-0400
 url: https://www.macstories.net/ios/adding-device-frames-to-iphone-xs-and-xs-max-screenshots-with-shortcuts/

--- a/content/links/2018-10-03-announcing-gatsby-2-0-0.md
+++ b/content/links/2018-10-03-announcing-gatsby-2-0-0.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2018-10-03-announcing-gatsby-2-0-0
 title: "Announcing Gatsby 2.0.0 🎉🎉🎉"
-summary:
+description:
   "We’re incredibly pleased to announce the 2nd major release of Gatsby! Gatsby is a blazing fast modern website and app generator. Thousands of developers use Gatsby to create amazing blogs, apps, marketing and ecommerce sites, documentation, and more! "
 date: 2018-10-03T12:00:00-04:00
 url: https://www.gatsbyjs.org/blog/2018-09-17-gatsby-v2/

--- a/content/links/2018-10-03-iphone-xs-why-its-a-whole-new-camera.md
+++ b/content/links/2018-10-03-iphone-xs-why-its-a-whole-new-camera.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2018-10-03-iphone-xs-why-its-a-whole-new-camera
 title: "iPhone XS: Why It’s A Whole New Camera"
-summary:
+description:
   "Last week we detailed the camera hardware changes of the iPhone XS vs. the iPhone X, and I wondered why Apple’s keynote focused on changes in camera software rather than the new hardware. After testing the iPhone XS cameras for the last week, I get it. "
 date: 2018-10-03T12:00:00-04:00
 url: https://blog.halide.cam/iphone-xs-why-its-a-whole-new-camera-ddf9780d714c

--- a/content/links/2018-10-03-lego-apple-park.md
+++ b/content/links/2018-10-03-lego-apple-park.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2018-10-03-lego-apple-park
 title: "Lego Apple Park"
-summary:
+description:
   "The real Apple Park covers 175 acres, and while this Lego model is only 1/650 scale, it's impressive nonetheless. Designed and built over the course of two years by automotive engineer and brick enthusiast Spencer Rezkalla, it measures 19 square feet and weighs over 75 pounds. "
 date: 2018-10-03T22:00:00-04:00
 url: https://uncrate.com/lego-apple-park/

--- a/content/links/2018-10-04-homekit-support-rolling-out-for-netatmo-welcome-security-camera.md
+++ b/content/links/2018-10-04-homekit-support-rolling-out-for-netatmo-welcome-security-camera.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2018-10-04-homekit-support-rolling-out-for-netatmo-welcome-security-camera
 title: "HomeKit support rolling out for Netatmo Welcome security camera"
-summary:
+description:
   "Netatmo is beginning to deploy HomeKit support for owners of its Welcome indoor security camera, beginning with beta testers, the company has confirmed."
 date: 2018-10-04T12:00:00-04:00
 url: https://www.google.com/amp/s/appleinsider.com/articles/18/10/02/homekit-support-rolling-out-for-netatmo-welcome-security-camera/amp/

--- a/content/links/2018-10-04-star-wars-the-mandalorian-list-of-directors-revealed.md
+++ b/content/links/2018-10-04-star-wars-the-mandalorian-list-of-directors-revealed.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2018-10-04-star-wars-the-mandalorian-list-of-directors-revealed
 title: "Star Wars 'The Mandalorian' image, list of directors revealed"
-summary:
+description:
   "Taika Waititi, Bryce Dallas Howard and Rick Famuyiwa are all in line to direct episodes. A day after we learned the name of the first live-action Star Wars TV show destined for Disney's unnamed subscription streaming service, the official website has posted this image of The Mandalorian. "
 date: 2018-10-04T22:00:00-04:00
 url: https://www.engadget.com/amp/2018/10/04/the-mandalorian-star-wars-disney-streaming/

--- a/content/links/2018-10-09-we-use-too-many-damn-modals.md
+++ b/content/links/2018-10-09-we-use-too-many-damn-modals.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2018-10-09-we-use-too-many-damn-modals
 title: "We use too many damn modals."
-summary:
+description:
   "Let's just not. Help Modals are the crutch of the inarticulate designer and developer. "
 date: 2018-10-09T12:00:00-04:00
 url: https://modalzmodalzmodalz.com/

--- a/content/links/2018-10-10-apple-frames--a-shortcut-for-framing-screenshots-from-every-apple-device.md
+++ b/content/links/2018-10-10-apple-frames--a-shortcut-for-framing-screenshots-from-every-apple-device.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2018-10-10-apple-frames--a-shortcut-for-framing-screenshots-from-every-apple-device
 title: "Apple Frames: A Shortcut for Framing Screenshots from Every Apple Device"
-summary:
+description:
   "When I published my iPhone XS Frames shortcut two weeks ago, I noted that my goal was to eventually support screenshots and device templates from other Apple devices, starting with the Apple Watch and MacBook Pro. "
 date: 2018-10-10T12:00:00-04:00
 url: https://www.macstories.net/ios/apple-frames-a-shortcut-for-framing-screenshots-from-every-apple-device/

--- a/content/links/2018-10-15-apple-fixes-its-new-bagel-emoji-with-cream-cheese-and-a-doughier-consistency.md
+++ b/content/links/2018-10-15-apple-fixes-its-new-bagel-emoji-with-cream-cheese-and-a-doughier-consistency.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2018-10-15-apple-fixes-its-new-bagel-emoji-with-cream-cheese-and-a-doughier-consistency
 title: "Apple fixes its new bagel emoji with cream cheese and a doughier consistency"
-summary:
+description:
   "Apple’s most egregious crime in recent memory — a subpar bagel emoji — has been rectified, as first spotted by Jeremy Burge of Emojipedia. In the fourth beta release of iOS 12.1, it appears that the bagel has been replaced with a new icon that features both cream cheese and a doughier consistency more reminiscent of a fresh, hand-rolled bagel and not the frozen and machine-cut grocery store variety it was accused of emulating in its original form. "
 date: 2018-10-15T12:00:00-04:00
 url: https://www.theverge.com/tldr/2018/10/15/17981324/apple-fixes-bagel-emoji-cream-cheese-ios-12-iphone

--- a/content/links/2018-10-15-ten-console-tricks-to-debug-like-a-pro.md
+++ b/content/links/2018-10-15-ten-console-tricks-to-debug-like-a-pro.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2018-10-15-ten-console-tricks-to-debug-like-a-pro
 title: "10 Console tricks, to debug like a Pro."
-summary:
+description:
   "Okay, I know it’s kinda like a click-bait title, but trust me you’ll be surprised by what console can do. let’s start with some basic ones. 1. console.group(‘name’) and console.groupEnd(‘name’) As the name suggests it will group multiple logs in one single expandable group, you can even nest them you’d like further group them. console.group(‘groupName’) starts the group and console.groupEnd(‘groupName’) closes a group. there is a third function console.groupCollapsed which creates the group in collapsed mode. "
 date: 2018-10-15T12:00:00-04:00
 url: https://itnext.io/10-console-tricks-to-debug-like-a-pro-66ee2225ec57?gi=c054b070b105

--- a/content/links/2018-10-24-here-are-all-of-the-apple-logos-included-in-the-october-30-event-invites.md
+++ b/content/links/2018-10-24-here-are-all-of-the-apple-logos-included-in-the-october-30-event-invites.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2018-10-24-here-are-all-of-the-apple-logos-included-in-the-october-30-event-invites
 title: "Here Are All of the Apple Logos Included in the October 30 Event Invites"
-summary:
+description:
   "For its upcoming October 30th event, Apple sent out unique media invites this year, with a different Apple logo on each and every one. The artwork for the Apple logos varies from the abstract to the classic, with Apple tapping multiple artists for the design. "
 date: 2018-10-24T12:00:00-04:00
 url: https://www.macrumors.com/2018/10/24/all-the-apple-logos/amp/

--- a/content/links/2018-10-28-getting-started-with-react-hooks.md
+++ b/content/links/2018-10-28-getting-started-with-react-hooks.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2018-10-28-getting-started-with-react-hooks
 title: "Getting Started with React Hooks"
-summary:
+description:
   "React Hooks are a great new feature coming in React 16.7. React 16.6 brought some awesome new things like React.memo() and React.lazy and Suspense. The React team isn't stopping there. "
 date: 2018-10-28T12:00:00-05:00
 url: https://scotch.io/tutorials/getting-started-with-react-hooks

--- a/content/links/2018-10-29-whats-new-in-storybook-4-react-native.md
+++ b/content/links/2018-10-29-whats-new-in-storybook-4-react-native.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2018-10-29-whats-new-in-storybook-4-react-native
 title: "What’s new in Storybook 4.0 React Native"
-summary:
+description:
   "What’s new in Storybook 4.0 React Native On-device Storybook UI to make you more productive React Native is the second most popular framework for Storybook. "
 date: 2018-10-29T12:00:00-04:00
 url: https://medium.com/storybookjs/whats-new-in-storybook-4-0-react-native-741c7f481bbb

--- a/content/links/2018-11-02-litmus-behind-the-scenes--managing-our-remote-engineering-team.md
+++ b/content/links/2018-11-02-litmus-behind-the-scenes--managing-our-remote-engineering-team.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2018-11-02-litmus-behind-the-scenes--managing-our-remote-engineering-team
 title: "Litmus Behind the Scenes: Managing our Remote Engineering Team"
-summary:
+description:
   "Ever wondered what it’s like to work remotely? Eddie Cianci, Director of Engineering at Litmus, shares what it’s like to work on a team that’s spread across the globe, and the benefits and challenges that come with it. "
 date: 2018-11-02T12:00:00-05:00
 url: https://litmus.com/blog/litmus-behind-the-scenes-managing-our-remote-engineering-team

--- a/content/links/2018-11-03-your-source-maps-are-broken--here-s-how-to-fix-them.md
+++ b/content/links/2018-11-03-your-source-maps-are-broken--here-s-how-to-fix-them.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2018-11-03-your-source-maps-are-broken--here-s-how-to-fix-them
 title: "Your Source Maps are Broken. Here's How to Fix Them"
-summary:
+description:
   "Source maps are awesome. Why? Because they are used to display your original JavaScript while debugging, which is a lot easier to look at than minified production code. "
 date: 2018-11-03T12:00:00-05:00
 url: https://scotch.io/tutorials/your-source-maps-are-broken-heres-how-to-fix-them

--- a/content/links/2018-11-06-how-we-used-gatsby-js-to-build-a-blazing-fast-e-commerce-site.md
+++ b/content/links/2018-11-06-how-we-used-gatsby-js-to-build-a-blazing-fast-e-commerce-site.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2018-11-06-how-we-used-gatsby-js-to-build-a-blazing-fast-e-commerce-site
 title: "How We Used Gatsby.js to Build a Blazing Fast E-Commerce Site"
-summary:
+description:
   "How We Used Gatsby.js to Build a Blazing Fast E-Commerce Site Flamingo has landed! Harry’s, Flamingo’s parent company, serves over one million female customers. "
 date: 2018-11-06T12:00:00-05:00
 url: https://medium.com/harrys-engineering/how-we-used-gatsby-js-to-build-a-blazing-fast-e-commerce-site-a9818145c67b

--- a/content/links/2018-11-16-creating-ios-12-shortcuts-with-javascript-and-shortcuts-js.md
+++ b/content/links/2018-11-16-creating-ios-12-shortcuts-with-javascript-and-shortcuts-js.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2018-11-16-creating-ios-12-shortcuts-with-javascript-and-shortcuts-js
 title: "Creating iOS 12 Shortcuts with JavaScript and Shortcuts JS 🧞"
-summary:
+description:
   "Creating iOS 12 Shortcuts with JavaScript and Shortcuts JS 🧞 TL;DR I created a library that allows you to create Shortcuts using JavaScript. "
 date: 2018-11-16T12:00:00-05:00
 url: https://medium.com/@joshfarrant/creating-ios-12-shortcuts-with-javascript-and-shortcuts-js-942420ca9904

--- a/content/links/2018-11-17-night-sight--seeing-in-the-dark-on-pixel-phones.md
+++ b/content/links/2018-11-17-night-sight--seeing-in-the-dark-on-pixel-phones.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2018-11-17-night-sight--seeing-in-the-dark-on-pixel-phones
 title: "Night Sight: Seeing in the Dark on Pixel Phones"
-summary:
+description:
   "Posted by Marc Levoy, Distinguished Engineer and Yael Pritch, Staff Software Engineer Night Sight is a new feature of the Pixel Camera app that lets you take sharp, clean photographs in very low light, even in light so dim you can't see much with your own eyes. "
 date: 2018-11-17T12:00:00-05:00
 url: https://ai.googleblog.com/2018/11/night-sight-seeing-in-dark-on-pixel.html?m=1

--- a/content/links/2018-12-12-proof-that-ios-still-hasn-t-gotten-undo-right.md
+++ b/content/links/2018-12-12-proof-that-ios-still-hasn-t-gotten-undo-right.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2018-12-12-proof-that-ios-still-hasn-t-gotten-undo-right
 title: "Proof That iOS Still Hasn’t Gotten Undo Right"
-summary:
+description:
   "I’ve been reading Apple’s App Store awards for 2018, and something jumped out at me. Both the iPhone and Mac apps of the year are image editors: Procreate Pocket on iPhone, Pixelmator Pro on Mac. Both are excellent apps, well-deserving of these awards. "
 date: 2018-12-12T12:00:00-05:00
 url: https://daringfireball.net/2018/12/ios_still_hasnt_gotten_undo_right

--- a/content/links/2018-12-15-what-do-you-name-color-variables.md
+++ b/content/links/2018-12-15-what-do-you-name-color-variables.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2018-12-15-what-do-you-name-color-variables
 title: "What do you name color variables?"
-summary:
+description:
   "What naming scheme do you use for color variables? Have you succeeded at writing CSS that uses color variables in a manner agnostic to the colors they represent? I've tried all of the following, and I have yet to succeed at writing CSS that works well with any color scheme. "
 date: 2018-12-15T12:00:00-05:00
 url: https://css-tricks.com/what-do-you-name-color-variables/

--- a/content/links/2018-12-20-animation-principles-for-ux-and-ui-designers.md
+++ b/content/links/2018-12-20-animation-principles-for-ux-and-ui-designers.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2018-12-20-animation-principles-for-ux-and-ui-designers
 title: "Animation principles for UX and UI designers"
-summary:
+description:
   "We spend a lot of time refining digital experiences and animation is often an afterthought when it comes to building them. In reality, many designers have no animation experience and we animate based on what “feels right”. "
 date: 2018-12-20T12:00:00-05:00
 url: https://uxplanet.org/animation-that-matters-adding-value-to-your-interface-65496fe4c182?gi=351cc2baf0e3

--- a/content/links/2018-12-28-remove-image-background.md
+++ b/content/links/2018-12-28-remove-image-background.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2018-12-28-remove-image-background
 title: "Remove Image Background"
-summary:
+description:
   "100% automatically – in 5 seconds – without a single click By uploading an image or URL you agree to our Terms of Service. This site is protected by reCAPTCHA and the Google Privacy Policy and Terms of Service apply. "
 date: 2018-12-28T12:00:00-05:00
 url: https://www.remove.bg/

--- a/content/links/2019-01-25-2019-css-wishlist.md
+++ b/content/links/2019-01-25-2019-css-wishlist.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2019-01-25-2019-css-wishlist
 title: "2019 CSS Wishlist"
-summary:
+description:
   "What do you wish CSS could do natively that it can't do now? First, let's review the last time we did this in 2013."
 date: 2019-01-25T12:00:00-05:00
 url: https://css-tricks.com/2019-css-wishlist/

--- a/content/links/2019-01-26-you-deserve-privacy-online.md
+++ b/content/links/2019-01-26-you-deserve-privacy-online.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2019-01-26-you-deserve-privacy-online
 title: "Tim Cook"
-summary:
+description:
   "GET TIME MAGAZINE For As Low As… 58¢ "
 date: 2019-01-26T12:00:00-05:00
 url: http://time.com/collection/davos-2019/5502591/tim-cook-data-privacy/

--- a/content/links/2019-01-27-apple-hosts-stanley-cup-nhl-commissioner-gary-bettman-all-stars-connor-mcdavid-and-auston-matthews.md
+++ b/content/links/2019-01-27-apple-hosts-stanley-cup-nhl-commissioner-gary-bettman-all-stars-connor-mcdavid-and-auston-matthews.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2019-01-27-apple-hosts-stanley-cup-nhl-commissioner-gary-bettman-all-stars-connor-mcdavid-and-auston-matthews
 title: "Apple Hosts Stanley Cup, NHL Commissioner Gary Bettman, All-Stars Connor McDavid and Auston Matthews"
-summary:
+description:
   "National Hockey League commissioner Gary Bettman and star players Connor McDavid of the Edmonton Oilers and Auston Matthews of the Toronto Maple Leafs sat down with Apple's marketing chief Phil Schiller on Thursday to discuss how technology is improving the game of hockey for players, coaches, and fans. "
 date: 2019-01-27T12:00:00-05:00
 url: https://www.macrumors.com/2019/01/27/apple-stanley-cup-nhl-bettman-mcdavid-matthews/

--- a/content/links/2019-02-14-captain-marvel.md
+++ b/content/links/2019-02-14-captain-marvel.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2019-02-14-captain-marvel
 title: "Captain Marvel"
-summary:
+description:
   "Set in the 1990s, Marvel Studios’ is an all-new adventure from a previously unseen period in the history of the Marvel Cinematic Universe that follows the journey of Carol Danvers as she becomes one of the universe’s most powerful heroes. "
 date: 2019-02-14T12:00:00-05:00
 url: https://www.marvel.com/captainmarvel

--- a/content/links/2019-02-14-css-scroll-snap-how-it-really-works.md
+++ b/content/links/2019-02-14-css-scroll-snap-how-it-really-works.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2019-02-14-css-scroll-snap-how-it-really-works
 title: "CSS Scroll Snap — How It Really Works"
-summary:
+description:
   "Remember the days you needed JS to have a nice looking scrolling on your page (gallery, slide show etc.)? Say bye bye to JS and say hi to CSS Scroll Snap. Long time ago, while CSS was on level 1, we’ve introduced with a property to scroll items and snap them to their container boundaries. "
 date: 2019-02-14T12:00:00-05:00
 url: https://blog.usejournal.com/css-scroll-snap-how-it-really-works-94d99db80bc9?gi=e3ffa9a27e6d

--- a/content/links/2019-03-19-an-exclusive-look-at-an-original-iphone-prototype.md
+++ b/content/links/2019-03-19-an-exclusive-look-at-an-original-iphone-prototype.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2019-03-19-an-exclusive-look-at-an-original-iphone-prototype
 title: "An exclusive look at an original iPhone prototype"
-summary:
+description:
   "“This is a day I’ve been looking forward to for two and half years,” said Steve Jobs, Apple’s late CEO, as he introduced the original iPhone on January 9th, 2007. Apple had developed the iPhone in secret over those two and a half years, and for many inside the company, the device had only been known by the codenames “M68” and “Purple 2.” "
 date: 2019-03-19T12:00:00-04:00
 url: https://www.theverge.com/2019/3/19/18263844/apple-iphone-prototype-m68-original-development-board-red

--- a/content/links/2019-04-17-why-notre-dame-was-a-tinderbox.md
+++ b/content/links/2019-04-17-why-notre-dame-was-a-tinderbox.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2019-04-17-why-notre-dame-was-a-tinderbox
 title: "Why Notre-Dame Was a Tinderbox"
-summary:
+description:
   "The fire started in the attic, a hidden, rarely visited space above Notre-Dame’s grand stone arches. The source of the fire, likely near the spire, could have been an electrical problem or a human error, like a worker tossing a cigarette. "
 date: 2019-04-17T12:00:00-04:00
 url: https://www.nytimes.com/interactive/2019/04/17/world/europe/notre-dame-cathedral-fire-spread.html

--- a/content/links/2019-04-21-retroflag-gpi.md
+++ b/content/links/2019-04-21-retroflag-gpi.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2019-04-21-retroflag-gpi
 title: "Retroflag GPi"
-summary:
+description:
   ""
 date: 2019-04-22T12:00:00-04:00
 url: http://retroflag.com/gpi-case.html

--- a/content/links/2019-05-02-building-the-new-facebook-com-with-react-graphql-and-relay.md
+++ b/content/links/2019-05-02-building-the-new-facebook-com-with-react-graphql-and-relay.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2019-05-02-building-the-new-facebook-com-with-react-graphql-and-relay
 title: "Building the New facebook.com with React, GraphQL and Relay"
-summary:
+description:
   "Open source projects like React, GraphQL and Relay are powering more and more Facebook services. In this session, we'll discuss how we use the latest features of these technologies, like React Suspense, to help deliver a high quality, modern web experience at Facebook. "
 date: 2019-05-02T12:00:00-04:00
 url: https://developers.facebook.com/videos/2019/building-the-new-facebookcom-with-react-graphql-and-relay/

--- a/content/links/2019-05-02-watch-the-electric-acid-surfboard-test-starring-stephanie-gilmore.md
+++ b/content/links/2019-05-02-watch-the-electric-acid-surfboard-test-starring-stephanie-gilmore.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2019-05-02-watch-the-electric-acid-surfboard-test-starring-stephanie-gilmore
 title: "Watch: The Electric Acid Surfboard Test, Starring Stephanie Gilmore"
-summary:
+description:
   "Here she is, beauties: The Electric Acid Surfboard Test 2019, starring The Queen, 7x World Champ, and Stab's Surfer of the Year—Miss Stephanie Louise Gilmore. With the generous support of our friends at Corona, this year's full-length flick is gratis—so take the coin you ain't spending on this gem, and toss it down on a cold sixer of Corona Ligera to share amongst friends while viewing. "
 date: 2019-05-02T12:00:00-04:00
 url: https://stabmag.com/stabcinema/stephanie-gilmore-stab-the-electric-acid-surfboard-test/

--- a/content/links/2019-05-04-google-doodle-honors-eddie-aikau.md
+++ b/content/links/2019-05-04-google-doodle-honors-eddie-aikau.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2019-05-04-google-doodle-honors-eddie-aikau
 title: "Google Doodle Honors Eddie Aikau"
-summary:
+description:
   "Google looked a little different this morning. The tech giant decided to honor Eddie Aikau on what would’ve been his 73rd birthday with a Doodle on its search homepage."
 date: 2019-05-04T12:00:00-04:00
 url: https://www.surfline.com/surf-news/google-doodle-honors-eddie-aikau/50965

--- a/content/links/2019-05-06-making-web-components-for-different-contexts.md
+++ b/content/links/2019-05-06-making-web-components-for-different-contexts.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2019-05-06-making-web-components-for-different-contexts
 title: "Making Web Components for Different Contexts"
-summary:
+description:
   "This article isn’t about how to build web components. Caleb Williams already wrote a comprehensive guide about that recently. Let’s talk about how to work with them, what to consider when making them, and how to embrace them in your projects. "
 date: 2019-05-06T12:00:00-04:00
 url: https://css-tricks.com/making-web-components-for-different-contexts/

--- a/content/links/2019-05-06-microsoft-is-adding-the-linux-command-line-to-windows-10.md
+++ b/content/links/2019-05-06-microsoft-is-adding-the-linux-command-line-to-windows-10.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2019-05-06-microsoft-is-adding-the-linux-command-line-to-windows-10
 title: >-
     Microsoft is adding the Linux command line to Windows 10
-summary: >-
+description: >-
     Microsoft is reaching out to Linux developers in a way that the company never has before. "The Bash shell is coming to Windows. Yes, the real Bash is coming to Windows," said Microsoft's Kevin Gallo on stage at today's Build 2016 keynote.
 date: 2019-05-06T12:00:00-04:00
 url: https://www.theverge.com/2016/3/30/11331014/microsoft-windows-linux-ubuntu-bash

--- a/content/links/2019-05-06-this-macos-tool-automatically-opens-all-apple-news-links-in-safari.md
+++ b/content/links/2019-05-06-this-macos-tool-automatically-opens-all-apple-news-links-in-safari.md
@@ -2,7 +2,7 @@
 templateKey: link-post
 path: /links/2019-05-06-this-macos-tool-automatically-opens-all-apple-news-links-in-safari
 title: "This macOS tool automatically opens all Apple News links in Safari"
-summary:
+description:
   "With macOS Mojave last year, Apple brought its Apple News app to the Mac for the first time. Because of this change, Apple News URLs open directly in the Apple News app itself, bypassing Safari completely. "
 date: 2019-05-06T23:19:04-04:00
 url: https://9to5mac.com/2019/05/06/apple-news-mac-links-in-safari/

--- a/content/links/2019-05-08-automate-react-Native-deployments-part-1.md
+++ b/content/links/2019-05-08-automate-react-Native-deployments-part-1.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2019-05-08-automate-react-Native-deployments-part-1
 title: >-
     Automate React Native Deployment - Part 1
-summary: >-
+description: >-
     React Native has its frustrating quirks and time-consuming challenges, as any library as heavy as React Native might. Automating deployment has been one of those challenges.
 date: 2019-05-08T09:05:53-04:00
 url: https://timmywil.com/blog/automate-react-native-deployment-part-1/

--- a/content/links/2019-05-08-responsible-javascript-part-i.md
+++ b/content/links/2019-05-08-responsible-javascript-part-i.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2019-05-08-responsible-javascript-part-i
 title: >-
     Responsible JavaScript: Part I
-summary: >-
+description: >-
     By the numbers, JavaScript is a performance liability. If the trend persists, the median page will be shipping at least 400 KB of it before too long, and that’s merely what’s transferred. Like other text-based resources, JavaScript is almost always served compressed—but that might be the only thing we’re getting consistently right in its delivery. 
 date: 2019-05-08T18:05:49-04:00
 url: https://alistapart.com/article/responsible-javascript-part-1/

--- a/content/links/2019-05-09-our-favorite-tips-and-tricks-for-making-the-most-out-of-apple-homekit.md
+++ b/content/links/2019-05-09-our-favorite-tips-and-tricks-for-making-the-most-out-of-apple-homekit.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2019-05-09-our-favorite-tips-and-tricks-for-making-the-most-out-of-apple-homekit
 title: >-
     Our favorite tips and tricks for making the most out of Apple HomeKit
-summary: >-
+description: >-
     HomeKit has made waves for being the easiest to use home automation platform, while still being extremely powerful. These are AppleInsider's top tips you may not know for getting the most out of your HomeKit setup.
 date: 2019-05-09T00:08:27-04:00
 url: https://appleinsider.com/articles/19/05/02/our-favorite-tips-and-tricks-for-making-the-most-out-of-apple-homekit

--- a/content/links/2019-05-11-introducing-github-package-registry.md
+++ b/content/links/2019-05-11-introducing-github-package-registry.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2019-05-11-introducing-github-package-registry
 title: >-
     Introducing GitHub Package Registry
-summary: >-
+description: >-
     Today, we’re excited to introduce GitHub Package Registry, a package management service that makes it easy to publish public or private packages next to your source code. GitHub Package Registry is fully integrated with GitHub, so you can use the same search, browsing, and management tools to find and publish packages as you do for your repositories. 
 date: 2019-05-11T21:40:27-04:00
 url: https://github.blog/2019-05-10-introducing-github-package-registry/

--- a/content/links/2019-05-13-breaking-to-a-new-row-with-flexbox.md
+++ b/content/links/2019-05-13-breaking-to-a-new-row-with-flexbox.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2019-05-13-breaking-to-a-new-row-with-flexbox
 title: >-
     Breaking to a new row with flexbox
-summary: >-
+description: >-
     Here’s the challenge: if you want to create a flexbox layout with several rows of items, how do you control which item ends up in which row? Presume you want to create a layout that looks something like this, with three stacked items and alternating full-width items: 
 date: 2019-05-13T09:02:43-04:00
 url: https://tobiasahlin.com/blog/flexbox-break-to-new-row/

--- a/content/links/2019-05-13-what-to-expect-from-marzipan.md
+++ b/content/links/2019-05-13-what-to-expect-from-marzipan.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2019-05-13-what-to-expect-from-marzipan
 title: >-
     What to Expect From Marzipan
-summary: >-
+description: >-
     It’s clear that this year’s WWDC is going to be a doozy. We’ve written here previously with our thoughts about Dark Mode, now it’s time to talk about iOS apps coming to the Mac. Of course I’m talking about Marzipan, a technology Apple introduced with few details during last year’s Keynote. 
 date: 2019-05-13T22:10:31-04:00
 url: https://blog.iconfactory.com/2019/05/what-to-expect-from-marzipan/

--- a/content/links/2019-05-15-designing-a-dark-theme-for-oled-iphones.md
+++ b/content/links/2019-05-15-designing-a-dark-theme-for-oled-iphones.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2019-05-15-designing-a-dark-theme-for-oled-iphones
 title: >-
     Designing a Dark Theme for OLED iPhones
-summary: >-
+description: >-
     Why using black backgrounds for your true-dark theme is a bad idea Vidit Bhargava 
 date: 2019-05-15T15:06:12-04:00
 url: https://medium.com/lookup-design/designing-a-dark-theme-for-oled-iphones-e13cdfea7ffe

--- a/content/links/2019-05-16-building-a-pure-css-animated-svg-spinner.md
+++ b/content/links/2019-05-16-building-a-pure-css-animated-svg-spinner.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2019-05-16-building-a-pure-css-animated-svg-spinner
 title: >-
     Building a pure CSS animated SVG spinner
-summary: >-
+description: >-
     In this article I’ll show you how to level up your loading indicators with a pure-CSS animated SVG loader inspired by Google’s Chrome and YouTube spinner. What are we making? A good loading indicator helps users feel a sense of progress, and the spinner which Google uses for Chrome and YouTube is one of my favourites. 
 date: 2019-05-16T00:25:15-04:00
 url: https://glennmccomb.com/articles/building-a-pure-css-animated-svg-spinner/

--- a/content/links/2019-05-16-google-fonts-is-adding-font-display-property.md
+++ b/content/links/2019-05-16-google-fonts-is-adding-font-display-property.md
@@ -3,7 +3,7 @@ templateKey: link-post
 path: /links/2019-05-16-google-fonts-is-adding-font-display-property
 title: >-
     Google Fonts is Adding font-display
-summary: >-
+description: >-
     At Google I/O this week, Anna Migas shared a photo of an Addy Osmani and Katie Hempenius session that dropped a font loading bombshell on the world. 
 
 “You will not have to self-host Google Fonts any more to get font-display: swap;”

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -30,8 +30,8 @@ module.exports = {
           twitter: false,
           yandex: false,
           windows: false,
-        }
-      }
+        },
+      },
     },
     {
       resolve: 'gatsby-plugin-google-tagmanager',
@@ -80,7 +80,134 @@ module.exports = {
               maxWidth: 1400,
               sizeByPixelDensity: true,
               quality: 100,
+            },
+          },
+        ],
+      },
+    },
+    {
+      resolve: `gatsby-plugin-feed`,
+      options: {
+        query: `
+          {
+            site {
+              siteMetadata {
+                title
+                description
+                siteUrl
+                site_url: siteUrl
+              }
             }
+          }
+        `,
+        feeds: [
+          {
+            serialize: ({ query: { site, allMarkdownRemark } }) => {
+              return allMarkdownRemark.edges.map(edge => {
+                return Object.assign({}, edge.node.frontmatter, {
+                  description: edge.node.frontmatter.description,
+                  date: edge.node.frontmatter.date,
+                  url: site.siteMetadata.siteUrl + edge.node.frontmatter.path,
+                  guid: site.siteMetadata.siteUrl + edge.node.frontmatter.path,
+                  custom_elements: [{ 'content:encoded': edge.node.html }],
+                })
+              })
+            },
+            query: `
+              {
+                allMarkdownRemark(
+                  sort: { order: DESC, fields: [frontmatter___date] },
+                  filter: { frontmatter: { templateKey: { in: ["blog-post", "link-post"] } } }
+                ) {
+                  edges {
+                    node {
+                      excerpt
+                      html
+                      frontmatter {
+                        path
+                        title
+                        description
+                        date
+                      }
+                    }
+                  }
+                }
+              }
+            `,
+            output: '/rss.xml',
+            title: 'All Posts',
+          },
+          {
+            serialize: ({ query: { site, allMarkdownRemark } }) => {
+              return allMarkdownRemark.edges.map(edge => {
+                return Object.assign({}, edge.node.frontmatter, {
+                  description: edge.node.frontmatter.description,
+                  date: edge.node.frontmatter.date,
+                  url: site.siteMetadata.siteUrl + edge.node.frontmatter.path,
+                  guid: site.siteMetadata.siteUrl + edge.node.frontmatter.path,
+                  custom_elements: [{ 'content:encoded': edge.node.html }],
+                })
+              })
+            },
+            query: `
+              {
+                allMarkdownRemark(
+                  sort: { order: DESC, fields: [frontmatter___date] },
+                  filter: { frontmatter: { templateKey: { eq: "blog-post" } } }
+                ) {
+                  edges {
+                    node {
+                      excerpt
+                      html
+                      frontmatter {
+                        path
+                        title
+                        description
+                        date
+                      }
+                    }
+                  }
+                }
+              }
+            `,
+            output: '/blog/rss.xml',
+            title: 'Blog Posts',
+          },
+          {
+            serialize: ({ query: { site, allMarkdownRemark } }) => {
+              return allMarkdownRemark.edges.map(edge => {
+                return Object.assign({}, edge.node.frontmatter, {
+                  description: edge.node.frontmatter.description,
+                  date: edge.node.frontmatter.date,
+                  url: site.siteMetadata.siteUrl + edge.node.frontmatter.path,
+                  guid: site.siteMetadata.siteUrl + edge.node.frontmatter.path,
+                  custom_elements: [{ 'content:encoded': edge.node.html }],
+                })
+              })
+            },
+            query: `
+              {
+                allMarkdownRemark(
+                  sort: { order: DESC, fields: [frontmatter___date] },
+                  filter: { frontmatter: { templateKey: { eq: "link-post" } } }
+                ) {
+                  edges {
+                    node {
+                      excerpt
+                      html
+                      frontmatter {
+                        path
+                        title
+                        description
+                        date
+                      }
+                    }
+                  }
+                }
+              }
+            `,
+            output: '/links/rss.xml',
+            title: 'Links',
           },
         ],
       },
@@ -102,4 +229,4 @@ module.exports = {
       },
     },
   ],
-};
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "gatsby-plugin-canonical-urls": "~2.0.8",
     "gatsby-plugin-catch-links": "~2.0.9",
     "gatsby-plugin-favicon": "~3.1.0",
+    "gatsby-plugin-feed": "^2.2.0",
     "gatsby-plugin-google-tagmanager": "~2.0.7",
     "gatsby-plugin-netlify": "~2.0.6",
     "gatsby-plugin-netlify-cache": "^1.1.0",

--- a/src/components/links/link-item.js
+++ b/src/components/links/link-item.js
@@ -7,7 +7,7 @@ import { Image } from '../shared'
 import SEO from '../seo'
 import Tags from '../tags'
 
-const Summary = styled('blockquote')`
+const Description = styled('blockquote')`
   font-size: 0.85rem;
   margin-top: -1.25rem !important;
 `
@@ -43,10 +43,10 @@ export const LinkItem = ({ post }) => {
             {post.frontmatter.title}
           </a>
         </Heading>
-        {post.frontmatter.summary && (
-          <Summary className="subtitle is-italic has-text-grey">
-            <p>{post.frontmatter.summary}</p>
-          </Summary>
+        {post.frontmatter.description && (
+          <Description className="subtitle is-italic has-text-grey">
+            <p>{post.frontmatter.description}</p>
+          </Description>
         )}
         <PostBody>
           <PostContent content={post.frontmatter.html} />

--- a/src/templates/link-post.js
+++ b/src/templates/link-post.js
@@ -39,7 +39,7 @@ export default props => (
           html
           frontmatter {
             title
-            summary
+            description
             path
             date(formatString: "MMMM DD, YYYY")
             url

--- a/yarn.lock
+++ b/yarn.lock
@@ -6376,6 +6376,16 @@ gatsby-plugin-favicon@~3.1.0:
     html-react-parser "^0.6.4"
     lodash "^4.17.11"
 
+gatsby-plugin-feed@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-feed/-/gatsby-plugin-feed-2.2.0.tgz#fde7c0de54364e21b58ed88c5b394cf58d530d89"
+  integrity sha512-/xbR/bfDWYyeCkgGqCXSURa1xvK3P8DlzHNu63fEXCsTR/fqi272SdRtlgpxIVqHJg11DmKyI+ZIWt1olAtoXA==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    fs-extra "^7.0.1"
+    lodash.merge "^4.6.0"
+    rss "^1.2.2"
+
 gatsby-plugin-google-tagmanager@~2.0.7:
   version "2.0.13"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-google-tagmanager/-/gatsby-plugin-google-tagmanager-2.0.13.tgz#c2a0e4cb02c8a96c591d022c50bdda4f8fa2a861"
@@ -9073,7 +9083,7 @@ lodash.memoize@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
-lodash.merge@^4.6.1:
+lodash.merge@^4.6.0, lodash.merge@^4.6.1:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
   integrity sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==
@@ -9525,6 +9535,18 @@ mime-db@1.40.0, "mime-db@>= 1.40.0 < 2", mime-db@^1.28.0:
   version "1.40.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.40.0.tgz#a65057e998db090f732a68f6c276d387d4126c32"
   integrity sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==
+
+mime-db@~1.25.0:
+  version "1.25.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.25.0.tgz#c18dbd7c73a5dbf6f44a024dc0d165a1e7b1c392"
+  integrity sha1-wY29fHOl2/b0SgJNwNFloeexw5I=
+
+mime-types@2.1.13:
+  version "2.1.13"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.13.tgz#e07aaa9c6c6b9a7ca3012c69003ad25a39e92a88"
+  integrity sha1-4HqqnGxrmnyjASxpADrSWjnpKog=
+  dependencies:
+    mime-db "~1.25.0"
 
 mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
   version "2.1.24"
@@ -12553,6 +12575,14 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
+rss@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/rss/-/rss-1.2.2.tgz#50a1698876138133a74f9a05d2bdc8db8d27a921"
+  integrity sha1-UKFpiHYTgTOnT5oF0r3I240nqSE=
+  dependencies:
+    mime-types "2.1.13"
+    xml "1.0.1"
+
 run-async@^2.2.0, run-async@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
@@ -14964,6 +14994,11 @@ xml2js@^0.4.5:
   dependencies:
     sax ">=0.6.0"
     xmlbuilder "~9.0.1"
+
+xml@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
+  integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
 
 xmlbuilder@^4.1.0:
   version "4.2.1"


### PR DESCRIPTION
- Adds RSS feeds for:
  - Main site feed (includes both blog and link posts)
  - Blog only feed
  - Links only feed
- Change link posts frontmatter `summary` to `description`
  - RSS feeds use description as one of the feed options so this will allow for more clearly matching that convention to avoid future confusion.
